### PR TITLE
Add functionality to save benchmark settings

### DIFF
--- a/zmq/python/src/hpc_streaming_skeletons/settings.py
+++ b/zmq/python/src/hpc_streaming_skeletons/settings.py
@@ -127,6 +127,10 @@ class OutputSettings(BaseModel):
         default=Path("out/results.csv"),
         description="Path to save test results CSV file",
     )
+    config_file: Path = Field(
+        default=Path("out/config.json"),
+        description="Path to save test configuration JSON file",
+    )
     plot_show: bool = Field(
         default=False, description="Whether to display plots interactively"
     )


### PR DESCRIPTION
Introduce a new method to save benchmark settings to a specified configuration file, enhancing the ability to manage and store benchmark configurations. Update the output settings to include a path for the configuration file.